### PR TITLE
Added macOS testing to GitHub Actions

### DIFF
--- a/.github/workflows/eera.yml
+++ b/.github/workflows/eera.yml
@@ -3,8 +3,61 @@ name: CI
 on: [push]
 
 jobs:
-  build:
-    runs-on: ubuntu-18.04
+  build_macOS_latest:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install Brew
+        run : /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
+
+      - name: Install GSL
+        run : brew update && brew install gsl
+
+      - name: Install cppcheck
+        run: brew install cppcheck
+
+      - name: Compile
+        run: |
+          mkdir build
+          cd build
+          cmake ..
+          make
+          
+      - name: Run regression tests
+        run: |
+          ./scripts/RunRegressionTests.sh
+          if [ $? -eq 0 ]; then
+            echo "Regression tests completed successfully"
+            exit 0
+          else
+            echo "Regression tests failed"
+            exit 1
+          fi
+
+      - name: Run unit tests
+        run: |
+          ./build/bin/Covid19EERAModel-unit_tests
+          if [ $? -eq 0 ]; then
+            echo "Unit tests completed successfully"
+            exit 0
+          else
+            echo "Unit tests failed"
+            exit 1
+          fi
+      - name: Run Cpp Check with internal parser
+        run: |
+           echo "Running CppCheck on files in 'src' with internal parser"
+           for i in src/*.h src/*.cpp test/unit/*.cpp; do 
+             if cppcheck --language=c++ --std=c++11 --error-exitcode=1 $i; then
+               continue
+             else
+               exit 1
+             fi
+           done
+
+  build_Ubuntu_latest:
+    runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v2
@@ -53,4 +106,4 @@ jobs:
              exit 1
            fi
          done
-
+  

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -6,8 +6,18 @@ ExternalProject_Add(
   googletest
   GIT_REPOSITORY https://github.com/google/googletest.git
   UPDATE_COMMAND ""
+  GIT_TAG release-1.10.0
   INSTALL_COMMAND ""
 )
+
+# assume built-in pthreads on MacOS
+IF(APPLE)
+    set(CMAKE_THREAD_LIBS_INIT "-lpthread")
+    set(CMAKE_HAVE_THREADS_LIBRARY 1)
+    set(CMAKE_USE_WIN32_THREADS_INIT 0)
+    set(CMAKE_USE_PTHREADS_INIT 1)
+    set(THREADS_PREFER_PTHREAD_FLAG ON)
+ENDIF()
 
 ExternalProject_Get_Property(googletest source_dir)
 set(GTEST_INCLUDE_DIRS ${source_dir}/googletest/include)


### PR DESCRIPTION
I have modified the GitHub Actions script to now also run a parallel job to build the model in macOS. Once we eventually work out how to implement the fix to Google Test stated in SCRC-120 this will ensure compatibility with both Mac and Linux.