### PR TITLE
Removed 'system' from logging and replaced with logs directory

### DIFF
--- a/src/Utilities.h
+++ b/src/Utilities.h
@@ -53,10 +53,6 @@ class logging_stream
 	strftime(buffer,sizeof(buffer),"%d-%m-%Y_%H-%M-%S",timeinfo);
 	std::string str(buffer);
 
-	std::string _command = "mkdir -p "+out_dir+"/logs";
-
-	system(_command.c_str());
-
 	std::string _file_name = out_dir+"/logs/run_"+str+".log";
 
 	log_fstream = std::ofstream(_file_name);


### PR DESCRIPTION
I read that using the `system` function can be dangerous because it passes commands direct to the computers command line. It is recommend not to use it so I have removed it from the `logging_stream` class. Because commands like `mkdir` within C++ may not be universal I have instead made the `logs` folder part of the repository for now.