### PR TITLE
Added timestamp to end of output files

### DIFF
--- a/scripts/CheckRunOutputs.sh
+++ b/scripts/CheckRunOutputs.sh
@@ -38,7 +38,10 @@ else
 	difference_count=0
 	for expected_filepath in $EXPECTED_OUTPUTS_DIR/*.txt
 	do
-	  actual_filepath=$ACTUAL_OUTPUTS_DIR/$(basename $expected_filepath)
+	  filename=$(basename $expected_filepath)
+	  filename="${filename%.*}"
+	  actual_filepath=$(find $ACTUAL_OUTPUTS_DIR -name "${filename}*")
+	  actual_filepath=${ACTUAL_OUTPUTS_DIR}/$(basename $actual_filepath)
 	  if [[ ! -f $actual_filepath ]]; then
 	    echo "ERROR: Failed to find expected file $actual_filepath"
 		missing_file_count=$((missing_file_count+1))

--- a/src/IO.cpp
+++ b/src/IO.cpp
@@ -147,13 +147,13 @@ EERAModel::InputObservations ReadObservationsFromFiles()
 }
 
 void WriteOutputsToFiles(int smc, int herd_id, int Nparticle, int nPar, 
-	const std::vector<EERAModel::particle>& particleList, const std::string& outDirPath)
+	const std::vector<EERAModel::particle>& particleList, const std::string& outDirPath, EERAModel::Utilities::logging_stream::Sptr log)
 {
 	std::stringstream namefile, namefile_simu, namefile_ends;
-	namefile << (outDirPath + "/output_abc-smc_particles_step") << smc << "_shb"<< herd_id << ".txt";
-	namefile_simu << (outDirPath + "/output_abc-smc_simu_step") << smc << "_shb"<< herd_id << ".txt";
-	namefile_ends << (outDirPath + "/output_abc-smc_ends_step") << smc << "_shb"<< herd_id << ".txt";		
-	
+	namefile << (outDirPath + "/output_abc-smc_particles_step") << smc << "_shb"<< herd_id << "_" << log->getLoggerTime() << ".txt";
+	namefile_simu << (outDirPath + "/output_abc-smc_simu_step") << smc << "_shb"<< herd_id << "_" << log->getLoggerTime() << ".txt";
+	namefile_ends << (outDirPath + "/output_abc-smc_ends_step") << smc << "_shb"<< herd_id << "_" << log->getLoggerTime() << ".txt";		
+
 	std::ofstream output_step (namefile.str().c_str());
 	std::ofstream output_simu (namefile_simu.str().c_str());
 	std::ofstream output_ends (namefile_ends.str().c_str());

--- a/src/IO.h
+++ b/src/IO.h
@@ -3,6 +3,7 @@
 #include "ModelTypes.h"
 
 #include <string>
+#include "Utilities.h"
 
 #ifndef ROOT_DIR
 #error Macro ROOT_DIR must be defined!
@@ -40,7 +41,8 @@ EERAModel::InputObservations ReadObservationsFromFiles();
  * @param outDirPath Path to the directory in which the output files should be placed
  */
 void WriteOutputsToFiles(int smc, int herd_id, int Nparticle, int nPar, 
-	const std::vector<EERAModel::particle>& particleList, const std::string& outDirPath);
+	const std::vector<EERAModel::particle>& particleList, const std::string& outDirPath,
+	EERAModel::Utilities::logging_stream::Sptr log);
 
 } // namespace IO
 } // namespace EERAModel

--- a/src/Model.cpp
+++ b/src/Model.cpp
@@ -329,7 +329,7 @@ void Run(EERAModel::ModelInputParameters& modelInputParameters,
 		//break the ABC-smc at the step where no particles were accepted
 		if (prevAcceptedParticleCount > 0) {
 			IO::WriteOutputsToFiles(smc, modelInputParameters.herd_id, prevAcceptedParticleCount,
-				modelInputParameters.nPar, particleList1, outDirPath);
+				modelInputParameters.nPar, particleList1, outDirPath, log);
 		}
 	}
 

--- a/src/Utilities.h
+++ b/src/Utilities.h
@@ -51,13 +51,13 @@ class logging_stream
 	timeinfo = localtime(&rawtime);
 
 	strftime(buffer,sizeof(buffer),"%d-%m-%Y_%H-%M-%S",timeinfo);
-	std::string str(buffer);
+	_log_time = std::string(buffer);
 
 	std::string _command = "mkdir -p "+out_dir+"/logs";
 
 	system(_command.c_str());
 
-	std::string _file_name = out_dir+"/logs/run_"+str+".log";
+	std::string _file_name = out_dir+"/logs/run_"+_log_time+".log";
 
 	log_fstream = std::ofstream(_file_name);
 	};
@@ -78,8 +78,12 @@ class logging_stream
 	func(log_fstream);
 	return *this;
 	}
+
+	std::string getLoggerTime() const {return _log_time;}
+	
  private:
 	std::ofstream log_fstream;
+	std::string _log_time = "";
 };
 } // namespace Utilities
 } // namespace EERAModel


### PR DESCRIPTION
Timestamps have now been added to the output files from model runs. The issue of getting the Regression Tests to recognise the new filenames has been addressed with some Bash scripting wizardy.

Closes SCRC-245