### PR TITLE
Fixed missing timestamp on output file

### DIFF
--- a/src/Utilities.h
+++ b/src/Utilities.h
@@ -51,7 +51,7 @@ class logging_stream
 	timeinfo = localtime(&rawtime);
 
 	strftime(buffer,sizeof(buffer),"%d-%m-%Y_%H-%M-%S",timeinfo);
-	std::string _log_time = std::string(buffer);
+	_log_time = std::string(buffer);
 	std::string _file_name = out_dir+"/logs/run_"+_log_time+".log";
 
 	log_fstream = std::ofstream(_file_name);


### PR DESCRIPTION
Timestamp was found to be missing from output files due to the `_log_time` member of the `logging_stream` being overwritten. Simple fix applied.