### PR TITLE
Clang-tidy suggestions for IO.cpp and IO.h implemented.

### DIFF
--- a/src/IO.cpp
+++ b/src/IO.cpp
@@ -1,6 +1,5 @@
 #include "IO.h"
 #include "ModelCommon.h"
-#include "IniFile.h"
 #include "Utilities.h"
 
 #include <valarray>
@@ -327,30 +326,6 @@ void WritePredictionsToFiles(Status status, std::vector<std::vector<int>>& end_c
 	output_simu.close();
 	output_ends.close();
 	output_full.close();
-}
-
-template <typename ParseVariableType>
-ParseVariableType ReadNumberFromFile(std::string SettingName, std::string SettingCategory, const std::string& filePath) 
-{
-	std::string SettingValue = CIniFile::GetValue(SettingName, SettingCategory, filePath);
-
-	char* endptr = nullptr;
-	ParseVariableType Value;
-	if (std::is_same<ParseVariableType, double>::value) { Value = strtod(SettingValue.c_str(), &endptr); }
-	if (std::is_same<ParseVariableType, int>::value) { Value = strtol(SettingValue.c_str(), &endptr, 0); }
-
-	/* Error Handling for strtod or strtol functions*/
-	if (Value == -HUGE_VAL || Value == HUGE_VAL || endptr == SettingValue.c_str())
-	{
-		std::stringstream SettingParseError;
-		SettingParseError << std::endl;
-		SettingParseError << "Invalid value in Parameter File: " << filePath.c_str() <<  std::endl;
-		SettingParseError << "Category: " << SettingCategory.c_str() << std::endl;
-		SettingParseError << "Setting: " << SettingName.c_str() << std::endl;
-		SettingParseError << "Value: " << SettingValue.c_str() << std::endl;
-		throw std::runtime_error(SettingParseError.str());
-	}
-	return Value;
 }
 
 } // namespace IO

--- a/src/IO.cpp
+++ b/src/IO.cpp
@@ -19,14 +19,14 @@ ModelInputParameters ReadParametersFromFile(const std::string& filePath, const U
 
 	//Settings
 	//modelInputParameters.herd_id = atoi(parameters.GetValue_modif(&SettingName, &SettingCategory, &filePath).c_str());
-	modelInputParameters.herd_id = StrToNumber<int>("shb_id", "Settings", filePath);
+	modelInputParameters.herd_id = ReadNumberFromFile<int>("shb_id", "Settings", filePath);
 
 	//time step for the modelling process
 	// modelInputParameters.tau = atof(parameters.GetValue("tau", "Settings", filePath).c_str());
-	modelInputParameters.tau = StrToNumber<double>("tau", "Settings", filePath);
+	modelInputParameters.tau = ReadNumberFromFile<double>("tau", "Settings", filePath);
 
 	//number of threads used for computation
-	modelInputParameters.num_threads = StrToNumber<int>("num_threads", "Settings", filePath);
+	modelInputParameters.num_threads = ReadNumberFromFile<int>("num_threads", "Settings", filePath);
 
     // Model structure
 	std::string SettingName = "model";
@@ -43,25 +43,25 @@ ModelInputParameters ReadParametersFromFile(const std::string& filePath, const U
 	SettingCategory = "Seed settings";
 	modelInputParameters.seedlist.seedmethod = CIniFile::GetValue(SettingName, SettingCategory, filePath);
 	if(modelInputParameters.seedlist.seedmethod == "random"){
-		modelInputParameters.seedlist.nseed = StrToNumber<int>("nseed", "Seed settings", filePath);
+		modelInputParameters.seedlist.nseed = ReadNumberFromFile<int>("nseed", "Seed settings", filePath);
 	} else if(modelInputParameters.seedlist.seedmethod == "background"){
-		modelInputParameters.seedlist.hrp = StrToNumber<int>("hrp", "Seed settings", filePath);
+		modelInputParameters.seedlist.hrp = ReadNumberFromFile<int>("hrp", "Seed settings", filePath);
 	} else {
 		(*log) << "Warning!!! Unknown method - using random seed method instead." << endl;
-		modelInputParameters.seedlist.nseed = StrToNumber<int>("nseed", "Seed settings", filePath);
+		modelInputParameters.seedlist.nseed = ReadNumberFromFile<int>("nseed", "Seed settings", filePath);
 	}
 	modelInputParameters.seedlist.use_fixed_seed = static_cast<bool>(
-		StrToNumber<int>("use_fixed_seed", "Seed settings", filePath)
+		ReadNumberFromFile<int>("use_fixed_seed", "Seed settings", filePath)
 	);
-	modelInputParameters.seedlist.seed_value = StrToNumber<int>(
+	modelInputParameters.seedlist.seed_value = ReadNumberFromFile<int>(
 		"seed_value", "Seed settings", filePath
 	);
 	
 	//Fit settings
-	modelInputParameters.nsteps = StrToNumber<int>("nsteps", "Fit settings", filePath);
-	modelInputParameters.nParticalLimit = StrToNumber<int>("nParticLimit", "Fit settings", filePath);
-	modelInputParameters.nSim = StrToNumber<int>("nSim", "Fit settings", filePath);
-	modelInputParameters.kernelFactor = StrToNumber<double>("kernelFactor", "Fit settings", filePath);
+	modelInputParameters.nsteps = ReadNumberFromFile<int>("nsteps", "Fit settings", filePath);
+	modelInputParameters.nParticalLimit = ReadNumberFromFile<int>("nParticLimit", "Fit settings", filePath);
+	modelInputParameters.nSim = ReadNumberFromFile<int>("nSim", "Fit settings", filePath);
+	modelInputParameters.kernelFactor = ReadNumberFromFile<double>("kernelFactor", "Fit settings", filePath);
 
 	//Tolerance settings
 	for (int ii = 1; ii <= modelInputParameters.nsteps; ++ii) {
@@ -71,45 +71,45 @@ ModelInputParameters ReadParametersFromFile(const std::string& filePath, const U
 	for (int ii = 0; ii < modelInputParameters.nsteps; ++ii) {
 		std::stringstream KeyName;
 		KeyName << "Key" << (ii + 1);
-		modelInputParameters.toleranceLimit[ii] = StrToNumber<double>(KeyName.str(), "Tolerance settings", filePath);
+		modelInputParameters.toleranceLimit[ii] = ReadNumberFromFile<double>(KeyName.str(), "Tolerance settings", filePath);
 	}
 
 	//Fixed parameters
-	modelInputParameters.paramlist.T_lat = StrToNumber<double>("T_lat", "Fixed parameters", filePath);
-	modelInputParameters.paramlist.juvp_s = StrToNumber<double>("juvp_s", "Fixed parameters", filePath);
-	modelInputParameters.paramlist.T_inf = StrToNumber<double>("T_inf", "Fixed parameters", filePath);
-	modelInputParameters.paramlist.T_rec = StrToNumber<double>("T_rec", "Fixed parameters", filePath);
-	modelInputParameters.paramlist.T_sym = StrToNumber<double>("T_sym", "Fixed parameters", filePath);
-	modelInputParameters.paramlist.T_hos = StrToNumber<double>("T_hos", "Fixed parameters", filePath);
-	modelInputParameters.day_shut = StrToNumber<int>("day_shut", "Fixed parameters", filePath);
-	modelInputParameters.totN_hcw = StrToNumber<int>("totN_hcw", "Fixed parameters", filePath);
-	modelInputParameters.paramlist.K = StrToNumber<int>("K", "Fixed parameters", filePath);
-	modelInputParameters.paramlist.inf_asym = StrToNumber<double>("inf_asym", "Fixed parameters", filePath);
+	modelInputParameters.paramlist.T_lat = ReadNumberFromFile<double>("T_lat", "Fixed parameters", filePath);
+	modelInputParameters.paramlist.juvp_s = ReadNumberFromFile<double>("juvp_s", "Fixed parameters", filePath);
+	modelInputParameters.paramlist.T_inf = ReadNumberFromFile<double>("T_inf", "Fixed parameters", filePath);
+	modelInputParameters.paramlist.T_rec = ReadNumberFromFile<double>("T_rec", "Fixed parameters", filePath);
+	modelInputParameters.paramlist.T_sym = ReadNumberFromFile<double>("T_sym", "Fixed parameters", filePath);
+	modelInputParameters.paramlist.T_hos = ReadNumberFromFile<double>("T_hos", "Fixed parameters", filePath);
+	modelInputParameters.day_shut = ReadNumberFromFile<int>("day_shut", "Fixed parameters", filePath);
+	modelInputParameters.totN_hcw = ReadNumberFromFile<int>("totN_hcw", "Fixed parameters", filePath);
+	modelInputParameters.paramlist.K = ReadNumberFromFile<int>("K", "Fixed parameters", filePath);
+	modelInputParameters.paramlist.inf_asym = ReadNumberFromFile<double>("inf_asym", "Fixed parameters", filePath);
 
 	//priors settings
-	modelInputParameters.nPar = StrToNumber<int>("nPar", "Priors settings", filePath);
-	modelInputParameters.prior_pinf_shape1 = StrToNumber<double>("prior_pinf_shape1", "Priors settings", filePath);
-	modelInputParameters.prior_pinf_shape2 = StrToNumber<double>("prior_pinf_shape2", "Priors settings", filePath);
-	modelInputParameters.prior_phcw_shape1 = StrToNumber<double>("prior_phcw_shape1", "Priors settings", filePath);
-	modelInputParameters.prior_phcw_shape2 = StrToNumber<double>("prior_phcw_shape2", "Priors settings", filePath);
-	modelInputParameters.prior_chcw_mean = StrToNumber<double>("prior_chcw_mean", "Priors settings", filePath);
-	modelInputParameters.prior_d_shape1 = StrToNumber<double>("prior_d_shape1", "Priors settings", filePath);
-	modelInputParameters.prior_d_shape2 = StrToNumber<double>("prior_d_shape2", "Priors settings", filePath);
-	modelInputParameters.prior_q_shape1 = StrToNumber<double>("prior_q_shape1", "Priors settings", filePath);
-	modelInputParameters.prior_q_shape2 = StrToNumber<double>("prior_q_shape2", "Priors settings", filePath);
-	modelInputParameters.prior_lambda_shape1 = StrToNumber<double>("prior_lambda_shape1", "Priors settings", filePath);
-	modelInputParameters.prior_lambda_shape2 = StrToNumber<double>("prior_lambda_shape2", "Priors settings", filePath);
+	modelInputParameters.nPar = ReadNumberFromFile<int>("nPar", "Priors settings", filePath);
+	modelInputParameters.prior_pinf_shape1 = ReadNumberFromFile<double>("prior_pinf_shape1", "Priors settings", filePath);
+	modelInputParameters.prior_pinf_shape2 = ReadNumberFromFile<double>("prior_pinf_shape2", "Priors settings", filePath);
+	modelInputParameters.prior_phcw_shape1 = ReadNumberFromFile<double>("prior_phcw_shape1", "Priors settings", filePath);
+	modelInputParameters.prior_phcw_shape2 = ReadNumberFromFile<double>("prior_phcw_shape2", "Priors settings", filePath);
+	modelInputParameters.prior_chcw_mean = ReadNumberFromFile<double>("prior_chcw_mean", "Priors settings", filePath);
+	modelInputParameters.prior_d_shape1 = ReadNumberFromFile<double>("prior_d_shape1", "Priors settings", filePath);
+	modelInputParameters.prior_d_shape2 = ReadNumberFromFile<double>("prior_d_shape2", "Priors settings", filePath);
+	modelInputParameters.prior_q_shape1 = ReadNumberFromFile<double>("prior_q_shape1", "Priors settings", filePath);
+	modelInputParameters.prior_q_shape2 = ReadNumberFromFile<double>("prior_q_shape2", "Priors settings", filePath);
+	modelInputParameters.prior_lambda_shape1 = ReadNumberFromFile<double>("prior_lambda_shape1", "Priors settings", filePath);
+	modelInputParameters.prior_lambda_shape2 = ReadNumberFromFile<double>("prior_lambda_shape2", "Priors settings", filePath);
 	
-	modelInputParameters.prior_ps_shape1 = StrToNumber<double>("prior_ps_shape1", "Priors settings", filePath);
-	modelInputParameters.prior_ps_shape2 = StrToNumber<double>("prior_ps_shape2", "Priors settings", filePath);
-	modelInputParameters.prior_rrd_shape1 = StrToNumber<double>("prior_rrd_shape1", "Priors settings", filePath);
-	modelInputParameters.prior_rrd_shape2 = StrToNumber<double>("prior_rrd_shape2", "Priors settings", filePath);
+	modelInputParameters.prior_ps_shape1 = ReadNumberFromFile<double>("prior_ps_shape1", "Priors settings", filePath);
+	modelInputParameters.prior_ps_shape2 = ReadNumberFromFile<double>("prior_ps_shape2", "Priors settings", filePath);
+	modelInputParameters.prior_rrd_shape1 = ReadNumberFromFile<double>("prior_rrd_shape1", "Priors settings", filePath);
+	modelInputParameters.prior_rrd_shape2 = ReadNumberFromFile<double>("prior_rrd_shape2", "Priors settings", filePath);
 
 	// modelInputParameters.run_type = parameters.GetValue("run_type", "Run type", filePath).c_str();
 	modelInputParameters.run_type = ModelModeId::INFERENCE;
 	// modelInputParameters.run_type = ModelModeId::PREDICTION;
 
-	modelInputParameters.posterior_parameter_select = StrToNumber<int>("posterior_parameter_select", "Posterior Parameters Select", filePath);
+	modelInputParameters.posterior_parameter_select = ReadNumberFromFile<int>("posterior_parameter_select", "Posterior Parameters Select", filePath);
 
 	return modelInputParameters;
 }
@@ -330,7 +330,7 @@ void WritePredictionsToFiles(Status status, std::vector<std::vector<int>>& end_c
 }
 
 template <typename ParseVariableType>
-ParseVariableType StrToNumber(std::string SettingName, std::string SettingCategory, const std::string& filePath) noexcept(false) 
+ParseVariableType ReadNumberFromFile(std::string SettingName, std::string SettingCategory, const std::string& filePath) 
 {
 	std::string SettingValue = CIniFile::GetValue(SettingName, SettingCategory, filePath);
 

--- a/src/IO.cpp
+++ b/src/IO.cpp
@@ -10,7 +10,7 @@
 namespace EERAModel {
 namespace IO {
 
-ModelInputParameters ReadParametersFromFile(const std::string* filePath, const Utilities::logging_stream::Sptr& log)
+ModelInputParameters ReadParametersFromFile(const std::string& filePath, const Utilities::logging_stream::Sptr& log)
 {
 	ModelInputParameters modelInputParameters;
 
@@ -30,7 +30,7 @@ ModelInputParameters ReadParametersFromFile(const std::string* filePath, const U
     // Model structure
 	std::string SettingName = "model";
 	std::string SettingCategory = "Settings";
-    std::string model_structure(CIniFile::GetValue(&SettingName, &SettingCategory, filePath));
+    std::string model_structure(CIniFile::GetValue(SettingName, SettingCategory, filePath));
     if ("irish" == model_structure) {
         modelInputParameters.model_structure = ModelStructureId::IRISH;
     } else {
@@ -40,7 +40,7 @@ ModelInputParameters ReadParametersFromFile(const std::string* filePath, const U
 	//Seed settings
 	SettingName = "seedmethod";
 	SettingCategory = "Seed settings";
-	modelInputParameters.seedlist.seedmethod = CIniFile::GetValue(&SettingName, &SettingCategory, filePath);
+	modelInputParameters.seedlist.seedmethod = CIniFile::GetValue(SettingName, SettingCategory, filePath);
 	if(modelInputParameters.seedlist.seedmethod == "random"){
 		modelInputParameters.seedlist.nseed = StrToNumber<int>("nseed", "Seed settings", filePath);
 	} else if(modelInputParameters.seedlist.seedmethod == "background"){
@@ -113,21 +113,21 @@ ModelInputParameters ReadParametersFromFile(const std::string* filePath, const U
 	return modelInputParameters;
 }
 
-std::vector<double> ReadPosteriorParametersFromFile(const std::string* filePath, const int* set_selection)
+std::vector<double> ReadPosteriorParametersFromFile(const std::string& filePath, const int& set_selection)
 {
 	// Temporary matrix to hold data from input file
 	std::vector<std::vector<double>> lines;
 	char delimiter = ',';
 	
-	lines = Utilities::read_csv<double>(filePath, delimiter);
+	lines = Utilities::read_csv<double>(&filePath, delimiter);
 
 	// Select line from input file and store result in another temporary vector
-	if ((*set_selection) >= static_cast<int>(lines.size())){
+	if (set_selection >= static_cast<int>(lines.size())){
 		std::stringstream SetSelectError;
 		SetSelectError << "Parameter set selection out of bounds! Please select between 0-" << (lines.size() - 1) << "..." << std::endl;
 		throw std::overflow_error(SetSelectError.str());
 	}
-	std::vector<double> line_select = lines[(*set_selection)];
+	std::vector<double> line_select = lines[set_selection];
 
 	/** Extract posterior parameters from selected line
 	 * the slicing is relevant to the format of the output file
@@ -329,9 +329,9 @@ void WritePredictionsToFiles(Status status, std::vector<std::vector<int>>& end_c
 }
 
 template <typename ParseVariableType>
-ParseVariableType StrToNumber(std::string SettingName, std::string SettingCategory, const std::string* filePath) noexcept(false) 
+ParseVariableType StrToNumber(std::string SettingName, std::string SettingCategory, const std::string& filePath) noexcept(false) 
 {
-	std::string SettingValue = CIniFile::GetValue(&SettingName, &SettingCategory, filePath);
+	std::string SettingValue = CIniFile::GetValue(SettingName, SettingCategory, filePath);
 
 	char* endptr = nullptr;
 	ParseVariableType Value;
@@ -343,7 +343,7 @@ ParseVariableType StrToNumber(std::string SettingName, std::string SettingCatego
 	{
 		std::stringstream SettingParseError;
 		SettingParseError << std::endl;
-		SettingParseError << "Invalid value in Parameter File: " << filePath->c_str() <<  std::endl;
+		SettingParseError << "Invalid value in Parameter File: " << filePath.c_str() <<  std::endl;
 		SettingParseError << "Category: " << SettingCategory.c_str() << std::endl;
 		SettingParseError << "Setting: " << SettingName.c_str() << std::endl;
 		SettingParseError << "Value: " << SettingValue.c_str() << std::endl;

--- a/src/IO.cpp
+++ b/src/IO.cpp
@@ -1,5 +1,6 @@
 #include "IO.h"
 #include "ModelCommon.h"
+#include "IniFile.h"
 #include "Utilities.h"
 
 #include <valarray>

--- a/src/IO.cpp
+++ b/src/IO.cpp
@@ -114,7 +114,7 @@ ModelInputParameters ReadParametersFromFile(const std::string& filePath, const U
 	return modelInputParameters;
 }
 
-std::vector<double> ReadPosteriorParametersFromFile(const std::string& filePath, const int& set_selection)
+std::vector<double> ReadPosteriorParametersFromFile(const std::string& filePath, int set_selection)
 {
 	// Temporary matrix to hold data from input file
 	std::vector<std::vector<double>> lines;

--- a/src/IO.cpp
+++ b/src/IO.cpp
@@ -119,7 +119,7 @@ std::vector<double> ReadPosteriorParametersFromFile(const std::string& filePath,
 	std::vector<std::vector<double>> lines;
 	char delimiter = ',';
 	
-	lines = Utilities::read_csv<double>(&filePath, delimiter);
+	lines = Utilities::read_csv<double>(filePath, delimiter);
 
 	// Select line from input file and store result in another temporary vector
 	if (set_selection >= static_cast<int>(lines.size())){
@@ -167,7 +167,7 @@ InputObservations ReadObservationsFromFiles(const Utilities::logging_stream::Spt
 	//last row is for all of scotland
 	
 	(*log) << "\t- " << scot_data_file << std::endl;
-	observations.cases = Utilities::read_csv<int>(&scot_data_file,',');
+	observations.cases = Utilities::read_csv<int>(scot_data_file,',');
 	
 	//Uploading observed death data
 	//Note: first vector is the vector of time. value of -1 indicate number of pigs in the herd
@@ -175,26 +175,26 @@ InputObservations ReadObservationsFromFiles(const Utilities::logging_stream::Spt
 	//last row is for all of scotland
 	
 	(*log) << "\t- " << scot_deaths_file << std::endl;
-	observations.deaths = Utilities::read_csv<int>(&scot_deaths_file,',');
+	observations.deaths = Utilities::read_csv<int>(scot_deaths_file,',');
 	
 	//Uploading population per age group
 	//columns are for each individual Health Borad
 	//last column is for Scotland
 	//rows are for each age group: [0] Under20,[1] 20-29,[2] 30-39,[3] 40-49,[4] 50-59,[5] 60-69,[6] Over70,[7] HCW
 	(*log) << "\t- " << scot_ages_file << std::endl;
-	observations.age_pop = Utilities::read_csv<double>(&scot_ages_file,',');	
+	observations.age_pop = Utilities::read_csv<double>(scot_ages_file,',');	
 	
 	//mean number of daily contacts per age group (overall)	
 	(*log) << "\t- " << waifw_norm_file << std::endl;
-	observations.waifw_norm = Utilities::read_csv<double>(&waifw_norm_file,',');
+	observations.waifw_norm = Utilities::read_csv<double>(waifw_norm_file,',');
 
 	//mean number of daily contacts per age group (home only)		
 	(*log) << "\t- " << waifw_home_file << std::endl;
-	observations.waifw_home = Utilities::read_csv<double>(&waifw_home_file,',');
+	observations.waifw_home = Utilities::read_csv<double>(waifw_home_file,',');
 	
 	//mean number of daily contacts per age group (not school, not work)			
 	(*log) << "\t- " << waifw_sdist_file << std::endl;
-	observations.waifw_sdist = Utilities::read_csv<double>(&waifw_sdist_file,',');	
+	observations.waifw_sdist = Utilities::read_csv<double>(waifw_sdist_file,',');	
 	
 	//Upload cfr by age group
 	//col0: p_h: probability of hospitalisation
@@ -202,14 +202,14 @@ InputObservations ReadObservationsFromFiles(const Utilities::logging_stream::Spt
 	//col2: p_d: probability of death, given hospitalisation
 	//rows are for each age group: [0] Under20,[1] 20-29,[2] 30-39,[3] 40-49,[4] 50-59,[5] 60-69,[6] Over70,[7] HCW
 	(*log) << "\t- " << cfr_byage_file << std::endl;
-	observations.cfr_byage = Utilities::read_csv<double>(&cfr_byage_file,',');	
+	observations.cfr_byage = Utilities::read_csv<double>(cfr_byage_file,',');	
 		
 	//Upload frailty probability p_f by age group
 	//columns are for each age group: [0] Under20,[1] 20-29,[2] 30-39,[3] 40-49,[4] 50-59,[5] 60-69,[6] Over70,[7] HCW
 	//rows are for each individual Health Borad
 	//last row is for Scotland
 	(*log) << "\t- " << scot_frail_file << std::endl;
-	observations.pf_pop = Utilities::read_csv<double>(&scot_frail_file,',');	
+	observations.pf_pop = Utilities::read_csv<double>(scot_frail_file,',');	
 
 	return observations;
 }

--- a/src/IO.h
+++ b/src/IO.h
@@ -4,6 +4,7 @@
 
 #include <string>
 #include "Utilities.h"
+#include "IniFile.h"
 
 #ifndef ROOT_DIR
 #error Macro ROOT_DIR must be defined!
@@ -25,10 +26,17 @@ namespace IO {
  * 
  * @return Model parameters
  */
-ModelInputParameters ReadParametersFromFile(const std::string& filePath, const Utilities::logging_stream::Sptr& log);
+ModelInputParameters ReadParametersFromFile(const std::string* filePath, const Utilities::logging_stream::Sptr& log);
 
-
-std::vector<double> ReadPosteriorParametersFromFile(const std::string& filePath, const int set_selection, const Utilities::logging_stream::Sptr& log);
+/**
+ * @brief Read model posterior parameters from a CSV file
+ * 
+ * @param filePath Path to CSV file
+ * @param set_selection Selection of row in CSV file for posterior parameters
+ * 
+ * @return Model posterior parameters
+ */
+std::vector<double> ReadPosteriorParametersFromFile(const std::string* filePath, const int* set_selection);
 
 /**
  * @brief Read in observations
@@ -53,9 +61,27 @@ void WriteOutputsToFiles(int smc, int herd_id, int Nparticle, int nPar,
 	const std::vector<EERAModel::particle>& particleList, const std::string& outDirPath,
 	const Utilities::logging_stream::Sptr& log);
 
+/**
+ * @brief Writes Prediction outputs to files
+ * 
+ * @param status Status object
+ * @param end_comps Matrix to hold the end states of the simulation organised by compartments
+ * @param outDirPath Path to output directory where output files will be stored
+ */
 void WritePredictionsToFiles(Status status, std::vector<std::vector<int>>& end_comps, 
 	const std::string& outDirPath, const Utilities::logging_stream::Sptr& log);
 
+/**
+ * @brief String to number conversion
+ * 
+ * @param SettingName Name of setting to retrieve
+ * @param SettingCategory Name of category for the setting in the INI file
+ * @param filePath File path of the INI file to be read
+ * 
+ * @return ParseVariableType, which is either int or double
+ */
+template <typename ParseVariableType>
+ParseVariableType StrToNumber(std::string SettingName, std::string SettingCategory, const std::string* filePath) noexcept(false);
 
 } // namespace IO
 } // namespace EERAModel

--- a/src/IO.h
+++ b/src/IO.h
@@ -71,16 +71,16 @@ void WritePredictionsToFiles(Status status, std::vector<std::vector<int>>& end_c
 	const std::string& outDirPath, const Utilities::logging_stream::Sptr& log);
 
 /**
- * @brief String to number conversion
+ * @brief Extract a numeric value from an INI file
  * 
- * @param SettingName Name of setting to retrieve
- * @param SettingCategory Name of category for the setting in the INI file
- * @param filePath File path of the INI file to be read
+ * @param SettingName Name of value to retrieve
+ * @param SettingCategory Name of category in which the value is located in the INI file
+ * @param filePath Path to the INI file
  * 
- * @return ParseVariableType, which is either int or double
+ * @return Numeric value (supported types are int or double)
  */
 template <typename ParseVariableType>
-ParseVariableType StrToNumber(std::string SettingName, std::string SettingCategory, const std::string& filePath) noexcept(false);
+ParseVariableType ReadNumberFromFile(std::string SettingName, std::string SettingCategory, const std::string& filePath);
 
 } // namespace IO
 } // namespace EERAModel

--- a/src/IO.h
+++ b/src/IO.h
@@ -1,10 +1,9 @@
 #pragma once
 
 #include "ModelTypes.h"
+#include "Utilities.h"
 
 #include <string>
-#include "Utilities.h"
-#include "IniFile.h"
 
 #ifndef ROOT_DIR
 #error Macro ROOT_DIR must be defined!

--- a/src/IO.h
+++ b/src/IO.h
@@ -26,7 +26,7 @@ namespace IO {
  * 
  * @return Model parameters
  */
-ModelInputParameters ReadParametersFromFile(const std::string* filePath, const Utilities::logging_stream::Sptr& log);
+ModelInputParameters ReadParametersFromFile(const std::string& filePath, const Utilities::logging_stream::Sptr& log);
 
 /**
  * @brief Read model posterior parameters from a CSV file
@@ -36,7 +36,7 @@ ModelInputParameters ReadParametersFromFile(const std::string* filePath, const U
  * 
  * @return Model posterior parameters
  */
-std::vector<double> ReadPosteriorParametersFromFile(const std::string* filePath, const int* set_selection);
+std::vector<double> ReadPosteriorParametersFromFile(const std::string& filePath, const int& set_selection);
 
 /**
  * @brief Read in observations
@@ -81,7 +81,7 @@ void WritePredictionsToFiles(Status status, std::vector<std::vector<int>>& end_c
  * @return ParseVariableType, which is either int or double
  */
 template <typename ParseVariableType>
-ParseVariableType StrToNumber(std::string SettingName, std::string SettingCategory, const std::string* filePath) noexcept(false);
+ParseVariableType StrToNumber(std::string SettingName, std::string SettingCategory, const std::string& filePath) noexcept(false);
 
 } // namespace IO
 } // namespace EERAModel

--- a/src/IO.h
+++ b/src/IO.h
@@ -35,7 +35,7 @@ ModelInputParameters ReadParametersFromFile(const std::string& filePath, const U
  * 
  * @return Model posterior parameters
  */
-std::vector<double> ReadPosteriorParametersFromFile(const std::string& filePath, const int& set_selection);
+std::vector<double> ReadPosteriorParametersFromFile(const std::string& filePath, int set_selection);
 
 /**
  * @brief Read in observations

--- a/src/IniFile.cpp
+++ b/src/IniFile.cpp
@@ -219,15 +219,16 @@ vector<CIniFile::Record> CIniFile::GetRecord(string KeyName, string SectionName,
 	return data;															// Return the Record
 }
 
-string CIniFile::GetValue(string KeyName, string SectionName, string FileName)
+string CIniFile::GetValue(string* KeyName, string* SectionName, const string* FileName)
 {
-	vector<Record> content = GetRecord(KeyName,SectionName, FileName);		// Get the Record
+	vector<Record> content = GetRecord((*KeyName), (*SectionName), (*FileName));		// Get the Record
 
 	if(!content.empty())													// Make sure there is a value to return
 		return content[0].Value;											// And return the value
 
 	return "";																// No value was found
 }
+
 
 bool CIniFile::SetValue(string KeyName, string Value, string SectionName, string FileName)
 {

--- a/src/IniFile.cpp
+++ b/src/IniFile.cpp
@@ -219,9 +219,9 @@ vector<CIniFile::Record> CIniFile::GetRecord(string KeyName, string SectionName,
 	return data;															// Return the Record
 }
 
-string CIniFile::GetValue(string* KeyName, string* SectionName, const string* FileName)
+string CIniFile::GetValue(string& KeyName, string& SectionName, const string& FileName)
 {
-	vector<Record> content = GetRecord((*KeyName), (*SectionName), (*FileName));		// Get the Record
+	vector<Record> content = GetRecord(KeyName, SectionName, FileName);		// Get the Record
 
 	if(!content.empty())													// Make sure there is a value to return
 		return content[0].Value;											// And return the value

--- a/src/IniFile.h
+++ b/src/IniFile.h
@@ -42,7 +42,7 @@ public:
 	static vector<Record> GetRecord(string KeyName, string SectionName, string FileName);
 	static vector<Record> GetSection(string SectionName, string FileName);
 	static vector<string> GetSectionNames(string FileName);
-	static string GetValue(string KeyName, string SectionName, string FileName);
+	static string GetValue(string* KeyName, string* SectionName, const string* FileName);
 	static bool RecordExists(string KeyName, string SectionName, string FileName);
 	static bool RenameSection(string OldSectionName, string NewSectionName, string FileName);
 	static bool SectionExists(string SectionName, string FileName);

--- a/src/IniFile.h
+++ b/src/IniFile.h
@@ -42,7 +42,7 @@ public:
 	static vector<Record> GetRecord(string KeyName, string SectionName, string FileName);
 	static vector<Record> GetSection(string SectionName, string FileName);
 	static vector<string> GetSectionNames(string FileName);
-	static string GetValue(string* KeyName, string* SectionName, const string* FileName);
+	static string GetValue(string& KeyName, string& SectionName, const string& FileName);
 	static bool RecordExists(string KeyName, string SectionName, string FileName);
 	static bool RenameSection(string OldSectionName, string NewSectionName, string FileName);
 	static bool SectionExists(string SectionName, string FileName);

--- a/src/Utilities.h
+++ b/src/Utilities.h
@@ -151,10 +151,10 @@ class logging_stream
  * @return vector of vectors containing read in data values
  */
 template<typename T>
-std::vector<std::vector<T>> read_csv(const std::string &inputfile, char delimiter)
+std::vector<std::vector<T>> read_csv(const std::string* inputfile, char delimiter)
 {
 	std::vector<std::vector<T> > data;
-	std::ifstream infile(inputfile.c_str());
+	std::ifstream infile(inputfile->c_str());
 	if (infile.fail())  { std::cout << "Input file not found" << std::endl; return data; }
 	std::string line;
 	std::vector<T> record;

--- a/src/Utilities.h
+++ b/src/Utilities.h
@@ -164,10 +164,10 @@ class logging_stream
  * @return vector of vectors containing read in data values
  */
 template<typename T>
-std::vector<std::vector<T>> read_csv(const std::string* inputfile, char delimiter)
+std::vector<std::vector<T>> read_csv(const std::string& inputfile, char delimiter)
 {
 	std::vector<std::vector<T> > data;
-	std::ifstream infile(inputfile->c_str());
+	std::ifstream infile(inputfile.c_str());
 	if (infile.fail())  { std::cout << "Input file not found" << std::endl; return data; }
 	std::string line;
 	std::vector<T> record;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -50,7 +50,7 @@ int main() {
 	std::cout << "PROJECT ROOT DIRECTORY:\t"+std::string(ROOT_DIR) << std::endl;
 	const std::string params_addr = std::string(ROOT_DIR)+"/data/parameters.ini";
 
-	ModelInputParameters modelInputParameters = IO::ReadParametersFromFile(&params_addr, logger);
+	ModelInputParameters modelInputParameters = IO::ReadParametersFromFile(params_addr, logger);
 
 	(*logger) << "[Parameters File]:\n    " << params_addr << std::endl;
 
@@ -87,8 +87,8 @@ int main() {
 		const std::string posterior_params_addr = std::string(ROOT_DIR)+"/data/example_posterior_parameter_sets.txt";
 		
 		modelInputParameters.posterior_param_list = 
-			IO::ReadPosteriorParametersFromFile(&posterior_params_addr, 
-												&modelInputParameters.posterior_parameter_select);
+			IO::ReadPosteriorParametersFromFile(posterior_params_addr, 
+												modelInputParameters.posterior_parameter_select);
 
         Prediction::PredictionFramework framework(model, modelInputParameters, observations, rng, out_dir, logger);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -50,7 +50,7 @@ int main() {
 	std::cout << "PROJECT ROOT DIRECTORY:\t"+std::string(ROOT_DIR) << std::endl;
 	const std::string params_addr = std::string(ROOT_DIR)+"/data/parameters.ini";
 
-	ModelInputParameters modelInputParameters = IO::ReadParametersFromFile(params_addr, logger);
+	ModelInputParameters modelInputParameters = IO::ReadParametersFromFile(&params_addr, logger);
 
 	(*logger) << "[Parameters File]:\n    " << params_addr << std::endl;
 
@@ -87,9 +87,8 @@ int main() {
 		const std::string posterior_params_addr = std::string(ROOT_DIR)+"/data/example_posterior_parameter_sets.txt";
 		
 		modelInputParameters.posterior_param_list = 
-			IO::ReadPosteriorParametersFromFile(posterior_params_addr, 
-												modelInputParameters.posterior_parameter_select, 
-												logger);
+			IO::ReadPosteriorParametersFromFile(&posterior_params_addr, 
+												&modelInputParameters.posterior_parameter_select);
 
         Prediction::PredictionFramework framework(model, modelInputParameters, observations, rng, out_dir, logger);
 


### PR DESCRIPTION
A new string to number converter added which can handle invalid values in the settings file.
Additionally changed a function in IniFile.cpp to take pointers as arguments instead of instances. Also added a few docstrings for functions, that were implemented in my last pull request (47).